### PR TITLE
Add `OpenFunc()` function

### DIFF
--- a/db.go
+++ b/db.go
@@ -25,7 +25,12 @@ type Db struct {
 
 // Open opens a new database connection.
 func Open(driverName, dataSourceName string) (*Db, error) {
-	db, err := sql.Open(driverName, dataSourceName)
+	return OpenFunc(driverName, dataSourceName, sql.Open)
+}
+
+// OpenFunc opens a new database connection by using the passed `fn`.
+func OpenFunc(driverName, dataSourceName string, fn func(string, string) (*sql.DB, error)) (*Db, error) {
+	db, err := fn(driverName, dataSourceName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds the `OpenFunc()` function that allows us to handle how
the DB connection will be opened. You can pass any function that has the
same signature as `sql.Open()` and it'll use it to start the connection.

The idea is to open the connections with DataDog [SQL wrapper][1] to
start collecting APM metrics for our queries.

[1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql