### PR TITLE
Add `QueryContext` methods for Jet objects

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,6 +1,7 @@
 package jet
 
 import (
+	"context"
 	"database/sql"
 )
 
@@ -69,5 +70,10 @@ func (db *Db) Begin() (*Tx, error) {
 
 // Query creates a prepared query that can be run with Rows or Run.
 func (db *Db) Query(query string, args ...interface{}) Runnable {
-	return newQuery(db, db, query, args...)
+	return db.QueryContext(context.Background(), query, args...)
+}
+
+// QueryContext creates a prepared query that can be run with Rows or Run.
+func (db *Db) QueryContext(ctx context.Context, query string, args ...interface{}) Runnable {
+	return newQuery(ctx, db, db, query, args...)
 }

--- a/tx.go
+++ b/tx.go
@@ -1,6 +1,7 @@
 package jet
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 )
@@ -15,7 +16,12 @@ type Tx struct {
 
 // Query creates a prepared query that can be run with Rows or Run.
 func (tx *Tx) Query(query string, args ...interface{}) Runnable {
-	q := newQuery(tx.tx, tx.db, query, args...)
+	return tx.QueryContext(context.Background(), query, args...)
+}
+
+// QueryContext creates a prepared query that can be run with Rows or Run.
+func (tx *Tx) QueryContext(ctx context.Context, query string, args ...interface{}) Runnable {
+	q := newQuery(ctx, tx.tx, tx.db, query, args...)
 	q.id = tx.qid
 	return q
 }


### PR DESCRIPTION
This commit adds `db/trx.QueryContext()` methods that are similar to
`Query()` but accept a context (same as the STD `sql.QueryContext`).

This will allow us to send tracing information to queries that will be
tied to a given span.

* https://golang.org/pkg/database/sql/#DB.QueryContext