### PR TITLE
Clubhouse-148415: Tweaking the mapping of complex type to support setting to blank

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -23,6 +23,15 @@ func (m *mapper) unpack(keys []string, values []interface{}, out interface{}) er
 func (m *mapper) unpackValue(keys []string, values []interface{}, out reflect.Value) error {
 	switch out.Interface().(type) {
 	case ComplexValue:
+		if values[0] == nil || reflect.ValueOf(values[0]).IsZero(){
+			if out.IsZero() {
+				return nil
+			}
+			if out.CanSet() {
+				out.Set(reflect.Zero(out.Type()))
+				return nil
+			}
+		}
 		if out.IsNil() {
 			out.Set(reflect.New(out.Type().Elem()))
 		}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -73,8 +73,13 @@ func (c *custom) Decode(v interface{}) error {
 	}
 	s, ok := v.(string)
 	if ok {
-		c.a = string(s[0])
-		c.b = string(s[1])
+		if len(s) > 1 {
+			c.a = string(s[0])
+			c.b = string(s[1])
+		} else {
+			c.a = ""
+			c.b = ""
+		}
 	}
 	return nil
 }
@@ -180,6 +185,144 @@ func TestUnpackStruct(t *testing.T) {
 		t.Fatal(v.M)
 	}
 }
+
+func TestUnpackStructExistingValueToEmpty(t *testing.T) {
+	keys := []string{"m"}
+	vals := []interface{}{
+		"",
+	}
+	mppr := &mapper{
+		conv: SnakeCaseConverter,
+	}
+
+	var v struct {
+		M   plainCustom
+	}
+	v.M = "abc"
+
+	err := mppr.unpack(keys, vals, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.M != "" {
+		t.Fatal(v.M)
+	}
+}
+
+func TestUnpackStructEmptyToEmpty(t *testing.T) {
+	keys := []string{"m"}
+	vals := []interface{}{
+		"",
+	}
+	mppr := &mapper{
+		conv: SnakeCaseConverter,
+	}
+
+	var v struct {
+		M   plainCustom
+	}
+
+	err := mppr.unpack(keys, vals, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.M != "" {
+		t.Fatal(v.M)
+	}
+}
+
+func TestUnpackStructExistingValueToNil(t *testing.T) {
+	keys := []string{"j"}
+	vals := []interface{}{
+		nil,
+	}
+	mppr := &mapper{
+		conv: SnakeCaseConverter,
+	}
+
+	var v struct {
+		J   *custom
+	}
+	v.J = &custom{a: "a", b: "b"}
+
+	err := mppr.unpack(keys, vals, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.J != nil {
+		t.Fatal(v.J)
+	}
+}
+
+func TestUnpackStructExistingValueNonPtrToEmpty(t *testing.T) {
+	keys := []string{"j"}
+	vals := []interface{}{
+		"",
+	}
+	mppr := &mapper{
+		conv: SnakeCaseConverter,
+	}
+
+	var v struct {
+		J   custom
+	}
+	v.J = custom{a: "a", b: "b"}
+
+	err := mppr.unpack(keys, vals, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.J.a != "" || v.J.b != "" {
+		t.Fatal(v.J)
+	}
+}
+
+func TestUnpackStructComplexExistingValueToEmpty(t *testing.T) {
+	keys := []string{"j"}
+	vals := []interface{}{
+		"",
+	}
+	mppr := &mapper{
+		conv: SnakeCaseConverter,
+	}
+
+	var v struct {
+		J   *custom
+	}
+	v.J = &custom{a: "a", b: "b"}
+
+	err := mppr.unpack(keys, vals, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.J != nil {
+		t.Fatal(v.J)
+	}
+}
+
+
+func TestUnpackStructNilComplexToNil(t *testing.T) {
+	keys := []string{"j"}
+	vals := []interface{}{
+		nil,
+	}
+	mppr := &mapper{
+		conv: SnakeCaseConverter,
+	}
+
+	var v struct {
+		J   *custom
+	}
+
+	err := mppr.unpack(keys, vals, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.J != nil {
+		t.Fatal(v.J)
+	}
+}
+
 
 func TestUnpackMap(t *testing.T) {
 	keys := []string{"ab_c", "c_d", "e"}


### PR DESCRIPTION
When loading values from the DB into an existing object if that object has an existing value and the DB value is nil this was not "resetting" the value, this will set the value to nil if it can (otherwise relies on the Decode to respect the fact the DB might not provide a value).

We were seeing this issue after blanking a Publish_At time on a model.

See [Clubhouse-148415](https://app.clubhouse.io/splice/story/148415/reloading-an-existing-model-does-not-update-timestamp-fields) for more details.