### PR TITLE
Clubhouse-148415: fix issue with interface nil not being nil

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -20,10 +20,26 @@ func (m *mapper) unpack(keys []string, values []interface{}, out interface{}) er
 	return m.unpackValue(keys, values, val)
 }
 
+func isNil(val interface{}) bool {
+	if val == nil {
+		return true
+	}
+	if reflect.ValueOf(val).IsZero() {
+		return true
+	}
+	if reflect.ValueOf(val).Kind() == reflect.Ptr {
+		if reflect.ValueOf(val).Elem().Kind() == reflect.Struct || reflect.ValueOf(val).Elem().Kind() == reflect.Interface {
+			return reflect.ValueOf(val).Elem().IsNil()
+		}
+	}
+
+	return false
+}
+
 func (m *mapper) unpackValue(keys []string, values []interface{}, out reflect.Value) error {
 	switch out.Interface().(type) {
 	case ComplexValue:
-		if values[0] == nil || reflect.ValueOf(values[0]).IsZero(){
+		if isNil(values[0]) {
 			if out.IsZero() {
 				return nil
 			}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -301,6 +301,32 @@ func TestUnpackStructComplexExistingValueToEmpty(t *testing.T) {
 }
 
 
+func TestUnpackStructNilLikeDBQuery(t *testing.T) {
+	keys := []string{"j"}
+	vals := make([]interface{}, 0, len(keys))
+	for i := 0; i < cap(vals); i++ {
+		vals = append(vals, new(interface{}))
+	}
+	mppr := &mapper{
+		conv: SnakeCaseConverter,
+	}
+
+	var v struct {
+		J   *custom
+	}
+	v.J = &custom{
+		a: "a", b: "b",
+	}
+
+	err := mppr.unpack(keys, vals, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.J != nil {
+		t.Fatal(v.J)
+	}
+}
+
 func TestUnpackStructNilComplexToNil(t *testing.T) {
 	keys := []string{"j"}
 	vals := []interface{}{


### PR DESCRIPTION
Go interfaces...my initial attempt worked fine in some cases but didn't cover how we actually use this with our db queries. We create an array of "blank" interfaces that can hold any value (for Scanning into) - this results in one of those kind of weird situations in which a nil value is not really a nil so the checks I had were not working correctly. 

This PR expands on the check to determine if the value is nil, I broke it into singular checks to make it a bit easier to debug and see which condition is being met. In this case I need to look at what the interface is referencing to determine if the value is nil (the check  inside `if reflect.ValueOf(val).Kind() == reflect.Ptr`).

Its a bit ugly but so is Go reflection in general.