### PR TITLE
Making LRU Prepared Stmt Cache Size configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ cpu.out
 
 *.sublime-project
 *.sublime-workspace
+
+.idea

--- a/db.go
+++ b/db.go
@@ -80,3 +80,7 @@ func (db *Db) Query(query string, args ...interface{}) Runnable {
 func (db *Db) QueryContext(ctx context.Context, query string, args ...interface{}) Runnable {
 	return newQuery(ctx, db.skipPreparedStmts, db, db, query, args...)
 }
+
+func (db *Db) CacheSize() int {
+	return db.lru.size()
+}

--- a/db.go
+++ b/db.go
@@ -3,7 +3,6 @@ package jet
 import (
 	"context"
 	"database/sql"
-	"strings"
 )
 
 // LogFunc can be set on the Db instance to allow query logging.
@@ -27,12 +26,12 @@ type Db struct {
 }
 
 // Open opens a new database connection.
-func Open(driverName, dataSourceName string, preparedStmtCacheSize int) (*Db, error) {
-	return OpenFunc(driverName, dataSourceName, sql.Open, preparedStmtCacheSize)
+func Open(driverName, dataSourceName string, usePreparedStmts bool, preparedStmtCacheSize int) (*Db, error) {
+	return OpenFunc(driverName, dataSourceName, sql.Open, usePreparedStmts, preparedStmtCacheSize)
 }
 
 // OpenFunc opens a new database connection by using the passed `fn`.
-func OpenFunc(driverName, dataSourceName string, fn func(string, string) (*sql.DB, error), preparedStmtCacheSize int) (*Db, error) {
+func OpenFunc(driverName, dataSourceName string, fn func(string, string) (*sql.DB, error), usePreparedStmts bool, preparedStmtCacheSize int) (*Db, error) {
 	db, err := fn(driverName, dataSourceName)
 	if err != nil {
 		return nil, err
@@ -42,7 +41,7 @@ func OpenFunc(driverName, dataSourceName string, fn func(string, string) (*sql.D
 		driver:            driverName,
 		source:            dataSourceName,
 		lru:               newLru(preparedStmtCacheSize),
-		skipPreparedStmts: strings.Contains(dataSourceName, "interpolateParams=true"),
+		skipPreparedStmts: usePreparedStmts,
 	}
 	j.DB = db
 

--- a/lru.go
+++ b/lru.go
@@ -19,9 +19,9 @@ type lruItem struct {
 	stmt *sql.Stmt
 }
 
-func newLru() *lru {
+func newLru(maxItems int) *lru {
 	return &lru{
-		maxItems: 500,
+		maxItems: maxItems,
 		keys:     make(map[string]*list.Element),
 		list:     list.New(),
 	}

--- a/lru.go
+++ b/lru.go
@@ -79,6 +79,10 @@ func (c *lru) clean() {
 	}
 }
 
+func (c *lru) size() int {
+	return c.list.Len()
+}
+
 // makeKey hashes the key to save some bytes
 func makeKey(k string) string {
 	buffer := sha1.New()

--- a/query.go
+++ b/query.go
@@ -7,24 +7,26 @@ import (
 )
 
 type jetQuery struct {
-	m     sync.Mutex
-	db    *Db
-	qo    queryObject
-	id    string
-	query string
-	args  []interface{}
-	ctx   context.Context
+	m                 sync.Mutex
+	db                *Db
+	qo                queryObject
+	id                string
+	query             string
+	args              []interface{}
+	ctx               context.Context
+	skipPreparedStmts bool
 }
 
 // newQuery initiates a new query for the provided query object (either *sql.Tx or *sql.DB)
-func newQuery(ctx context.Context, qo queryObject, db *Db, query string, args ...interface{}) *jetQuery {
+func newQuery(ctx context.Context, skipPreparedStmts bool, qo queryObject, db *Db, query string, args ...interface{}) *jetQuery {
 	return &jetQuery{
-		qo:    qo,
-		db:    db,
-		id:    newQueryId(),
-		query: query,
-		args:  args,
-		ctx:   ctx,
+		qo:                qo,
+		db:                db,
+		id:                newQueryId(),
+		query:             query,
+		args:              args,
+		ctx:               ctx,
+		skipPreparedStmts: skipPreparedStmts,
 	}
 }
 
@@ -44,6 +46,9 @@ func (q *jetQuery) Rows(v interface{}) (err error) {
 	useLru := true
 	switch q.qo.(type) {
 	case *sql.Tx:
+		useLru = false
+	}
+	if q.skipPreparedStmts {
 		useLru = false
 	}
 
@@ -74,30 +79,47 @@ func (q *jetQuery) Rows(v interface{}) (err error) {
 	}
 
 	// prepare statement
-	stmt, ok := q.db.lru.get(query)
-	if !useLru || !ok {
-		stmt, err = q.qo.Prepare(query)
+	var rows *sql.Rows
+	if q.skipPreparedStmts {
+		conn, err := q.db.DB.Conn(q.ctx)
 		if err != nil {
 			return err
 		}
-		if useLru {
-			q.db.lru.put(query, stmt)
-		} else {
-			defer stmt.Close()
+		defer conn.Close()
+
+		if v == nil {
+			_, err := conn.ExecContext(q.ctx, query, args...)
+			return err
 		}
+
+		rows, err = conn.QueryContext(q.ctx, query, args...)
+	} else {
+		stmt, ok := q.db.lru.get(query)
+		if !useLru || !ok {
+			stmt, err = q.qo.Prepare(query)
+			if err != nil {
+				return err
+			}
+			if useLru {
+				q.db.lru.put(query, stmt)
+			} else {
+				defer stmt.Close()
+			}
+		}
+		// If no rows need to be unpacked use Exec
+		if v == nil {
+			_, err := stmt.ExecContext(q.ctx, args...)
+			return err
+		}
+
+		// run query
+		rows, err = stmt.QueryContext(q.ctx, args...)
+		if err != nil {
+			return err
+		}
+
 	}
 
-	// If no rows need to be unpacked use Exec
-	if v == nil {
-		_, err := stmt.ExecContext(q.ctx, args...)
-		return err
-	}
-
-	// run query
-	rows, err := stmt.QueryContext(q.ctx, args...)
-	if err != nil {
-		return err
-	}
 	defer rows.Close()
 
 	cols, err := rows.Columns()


### PR DESCRIPTION
This adds some work around prepared stmts as a result of a prod outage where we reached the max allowed prepared stmts on MySQL. While this does not seem to be an on-going issue this makes the cache configurable and adds an option not to use prepared stmts (this is probably better done using [this option](https://github.com/go-sql-driver/mysql#interpolateparams) on the mysql driver). Also added a method to get the cache size for metric reporting.

We added a metric to track the number of prepared stmts in mysql with alerts at 20k and 25k and we seem to be running pretty steady after the DB reboot so these changes might not be needed (dashboard [here](https://splice.datadoghq.com/dashboard/ta7-rs9-p6w/mysql-prepared-stmt-cache?from_ts=1674471935253&to_ts=1674486335253&live=true)). That being said, making the config options available to API feel like a good thing even if we leave at the prior value of 500 and never disable prepared stmts. Otherwise we have to update this lib, merge, update api, and rebuild it before any change can be seen.