### PR TITLE
Fixing variable used to skip use of prepared stmts

### DIFF
--- a/db.go
+++ b/db.go
@@ -19,29 +19,29 @@ type Db struct {
 	// Defaults to SnakeCaseConverter.
 	ColumnConverter ColumnConverter
 
-	driver            string
-	source            string
-	lru               *lru
-	skipPreparedStmts bool
+	driver               string
+	source               string
+	lru                  *lru
+	disablePreparedStmts bool
 }
 
 // Open opens a new database connection.
-func Open(driverName, dataSourceName string, usePreparedStmts bool, preparedStmtCacheSize int) (*Db, error) {
-	return OpenFunc(driverName, dataSourceName, sql.Open, usePreparedStmts, preparedStmtCacheSize)
+func Open(driverName, dataSourceName string, disablePreparedStmts bool, preparedStmtCacheSize int) (*Db, error) {
+	return OpenFunc(driverName, dataSourceName, sql.Open, disablePreparedStmts, preparedStmtCacheSize)
 }
 
 // OpenFunc opens a new database connection by using the passed `fn`.
-func OpenFunc(driverName, dataSourceName string, fn func(string, string) (*sql.DB, error), usePreparedStmts bool, preparedStmtCacheSize int) (*Db, error) {
+func OpenFunc(driverName, dataSourceName string, fn func(string, string) (*sql.DB, error), disablePreparedStmts bool, preparedStmtCacheSize int) (*Db, error) {
 	db, err := fn(driverName, dataSourceName)
 	if err != nil {
 		return nil, err
 	}
 	j := &Db{
-		ColumnConverter:   SnakeCaseConverter, // default
-		driver:            driverName,
-		source:            dataSourceName,
-		lru:               newLru(preparedStmtCacheSize),
-		skipPreparedStmts: usePreparedStmts,
+		ColumnConverter:      SnakeCaseConverter, // default
+		driver:               driverName,
+		source:               dataSourceName,
+		lru:                  newLru(preparedStmtCacheSize),
+		disablePreparedStmts: disablePreparedStmts,
 	}
 	j.DB = db
 
@@ -77,7 +77,7 @@ func (db *Db) Query(query string, args ...interface{}) Runnable {
 
 // QueryContext creates a prepared query that can be run with Rows or Run.
 func (db *Db) QueryContext(ctx context.Context, query string, args ...interface{}) Runnable {
-	return newQuery(ctx, db.skipPreparedStmts, db, db, query, args...)
+	return newQuery(ctx, db.disablePreparedStmts, db, db, query, args...)
 }
 
 func (db *Db) CacheSize() int {

--- a/query.go
+++ b/query.go
@@ -7,26 +7,26 @@ import (
 )
 
 type jetQuery struct {
-	m                 sync.Mutex
-	db                *Db
-	qo                queryObject
-	id                string
-	query             string
-	args              []interface{}
-	ctx               context.Context
-	skipPreparedStmts bool
+	m                    sync.Mutex
+	db                   *Db
+	qo                   queryObject
+	id                   string
+	query                string
+	args                 []interface{}
+	ctx                  context.Context
+	disablePreparedStmts bool
 }
 
 // newQuery initiates a new query for the provided query object (either *sql.Tx or *sql.DB)
-func newQuery(ctx context.Context, skipPreparedStmts bool, qo queryObject, db *Db, query string, args ...interface{}) *jetQuery {
+func newQuery(ctx context.Context, disablePreparedStmts bool, qo queryObject, db *Db, query string, args ...interface{}) *jetQuery {
 	return &jetQuery{
-		qo:                qo,
-		db:                db,
-		id:                newQueryId(),
-		query:             query,
-		args:              args,
-		ctx:               ctx,
-		skipPreparedStmts: skipPreparedStmts,
+		qo:                   qo,
+		db:                   db,
+		id:                   newQueryId(),
+		query:                query,
+		args:                 args,
+		ctx:                  ctx,
+		disablePreparedStmts: disablePreparedStmts,
 	}
 }
 
@@ -48,7 +48,7 @@ func (q *jetQuery) Rows(v interface{}) (err error) {
 	case *sql.Tx:
 		useLru = false
 	}
-	if q.skipPreparedStmts {
+	if q.disablePreparedStmts {
 		useLru = false
 	}
 
@@ -80,7 +80,7 @@ func (q *jetQuery) Rows(v interface{}) (err error) {
 
 	// prepare statement
 	var rows *sql.Rows
-	if q.skipPreparedStmts {
+	if q.disablePreparedStmts {
 		conn, err := q.db.DB.Conn(q.ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION
Had some bad naming where I was mixing positive and negative in a single variable (so the parameter was positive verbage but was used in the negative in the assigned variable). This aligns those references.