### PR TITLE
Updated flags...again

### DIFF
--- a/db.go
+++ b/db.go
@@ -23,15 +23,16 @@ type Db struct {
 	source               string
 	lru                  *lru
 	usePreparedStmtCache bool
+	noPreparedStmts      bool
 }
 
 // Open opens a new database connection.
-func Open(driverName, dataSourceName string, preparedStmtCacheSize int) (*Db, error) {
-	return OpenFunc(driverName, dataSourceName, sql.Open, preparedStmtCacheSize)
+func Open(driverName, dataSourceName string, preparedStmtCacheSize int, noPreparedStmts bool) (*Db, error) {
+	return OpenFunc(driverName, dataSourceName, sql.Open, preparedStmtCacheSize, noPreparedStmts)
 }
 
 // OpenFunc opens a new database connection by using the passed `fn`.
-func OpenFunc(driverName, dataSourceName string, fn func(string, string) (*sql.DB, error), preparedStmtCacheSize int) (*Db, error) {
+func OpenFunc(driverName, dataSourceName string, fn func(string, string) (*sql.DB, error), preparedStmtCacheSize int, noPreparedStmts bool) (*Db, error) {
 	db, err := fn(driverName, dataSourceName)
 	if err != nil {
 		return nil, err
@@ -42,6 +43,7 @@ func OpenFunc(driverName, dataSourceName string, fn func(string, string) (*sql.D
 		source:               dataSourceName,
 		lru:                  newLru(preparedStmtCacheSize),
 		usePreparedStmtCache: preparedStmtCacheSize > 0,
+		noPreparedStmts:      noPreparedStmts,
 	}
 	j.DB = db
 
@@ -77,7 +79,7 @@ func (db *Db) Query(query string, args ...interface{}) Runnable {
 
 // QueryContext creates a prepared query that can be run with Rows or Run.
 func (db *Db) QueryContext(ctx context.Context, query string, args ...interface{}) Runnable {
-	return newQuery(ctx, db.usePreparedStmtCache, db, db, query, args...)
+	return newQuery(ctx, db.usePreparedStmtCache, db.noPreparedStmts, db, db, query, args...)
 }
 
 func (db *Db) CacheSize() int {


### PR DESCRIPTION
Struggling a little bit with the ergonomics here, this PR does 2 things, first it uses the queue size as an indicator of whether to cache prepared stmts (otherwise it will create a prepared stmt and close it immediately). Second there is a flag saying whether to use prepared statements at all. This was essentially what was there but in a more confusing way.