### PR TITLE
Switch to use sqlx as the underlying db connection instead of basic sql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/splice/jet
 
 go 1.18
+
+require github.com/jmoiron/sqlx v1.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
+github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,9 @@
+package jet
+
+import "context"
+
+// LogFunc can be set on the Db instance to allow query logging.
+type LogFunc func(ctx context.Context, queryId, query string, args ...interface{})
+
+func NoopLogFunc(_ context.Context, _, _ string, _ ...interface{}) {
+}

--- a/tx.go
+++ b/tx.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"github.com/jmoiron/sqlx"
 )
 
 // Tx represents a transaction instance.
 // It can be created using Begin on the *Db object.
 type Tx struct {
 	db  *Db
-	tx  *sql.Tx
+	tx  *sqlx.Tx
 	qid string
 }
 
@@ -36,16 +37,12 @@ func (tx *Tx) Exec(query string, args ...interface{}) (sql.Result, error) {
 
 // Commit commits the transaction
 func (tx *Tx) Commit() error {
-	if tx.db.LogFunc != nil {
-		tx.db.LogFunc(tx.qid, "COMMIT")
-	}
+	tx.db.LogFunc(context.Background(), tx.qid, "COMMIT")
 	return tx.tx.Commit()
 }
 
 // Rollback rolls back the transaction
 func (tx *Tx) Rollback() error {
-	if tx.db.LogFunc != nil {
-		tx.db.LogFunc(tx.qid, "ROLLBACK")
-	}
+	tx.db.LogFunc(context.Background(), tx.qid, "ROLLBACK")
 	return tx.tx.Rollback()
 }

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package jet
 import (
 	"context"
 	"database/sql"
+	"github.com/jmoiron/sqlx"
 )
 
 type Runnable interface {
@@ -13,8 +14,8 @@ type Runnable interface {
 }
 
 type queryObject interface {
-	Prepare(query string) (*sql.Stmt, error)
-	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	Preparex(query string) (*sqlx.Stmt, error)
+	QueryxContext(ctx context.Context, query string, args ...any) (*sqlx.Rows, error)
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 

--- a/util.go
+++ b/util.go
@@ -27,3 +27,11 @@ func newAlphanumericId(length int) string {
 	}
 	return string(buf)
 }
+
+type Closer interface {
+	Close() error
+}
+
+func closeQuietly(closer Closer) {
+	_ = closer.Close()
+}


### PR DESCRIPTION
Switches the underlying db connection to use sqlx.DB instead of the go sql.DB. I also tweaked some things like the logger and added a function to init with the driver instead of having this create the driver for you which will make integrating with platform's db initialization if we want.